### PR TITLE
added export of missing hydraulic components

### DIFF
--- a/src/Hydraulic/IsothermalCompressible/IsothermalCompressible.jl
+++ b/src/Hydraulic/IsothermalCompressible/IsothermalCompressible.jl
@@ -14,7 +14,7 @@ using IfElse: ifelse
 export HydraulicPort, HydraulicFluid
 include("utils.jl")
 
-export Cap, Tube, FixedVolume, DynamicVolume
+export Cap, Tube, FixedVolume, DynamicVolume, Open, FlowDivider, Valve, Volume, SpoolValve, SpoolValve2Way, Actuator
 include("components.jl")
 
 export MassFlow, Pressure, FixedPressure


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Some hydraulic components developend nicely in [src/Hydraulic/IsothermalCompressible/components.jl](url) are not exported.
Adding default export of these components into [src/Hydraulic/IsothermalCompressible/IsothermalCompressible.jl](url)

Components being exported:
- Open
- Flow divider
- Valve
- Volume
- SpoolValve
- SpoolValve2Way
- Actuator